### PR TITLE
Issue #11 - fix full widthing of blocks (alt, loop, etc) instead bound to inner content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/lmika/goseq
+
+go 1.15
+
+require (
+	github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/howeyc/fsnotify v0.9.0
+	github.com/seanpont/assert v0.0.0-20141212164842-4b06649e62f7
+	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb h1:EVl3FJLQCzSbgBezKo/1A4ADnJ4mtJZ0RvnNzDJ44nY=
+github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/howeyc/fsnotify v0.9.0 h1:0gtV5JmOKH4A8SsFxG2BczSeXWWPvcMT0euZt5gDAxY=
+github.com/howeyc/fsnotify v0.9.0/go.mod h1:41HzSPxBGeFRQKEEwgh49TRw/nKBsYZ2cF1OzPjSJsA=
+github.com/seanpont/assert v0.0.0-20141212164842-4b06649e62f7 h1:mhpEmKEJp3FEHEjWzM/81AknkumClUd8vb++rq9re7Q=
+github.com/seanpont/assert v0.0.0-20141212164842-4b06649e62f7/go.mod h1:+WaNQ7NBfx3wkC0KgS2Ee2U0ahkii9HIvaqUzaJXdjY=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 h1:QelT11PB4FXiDEXucrfNckHoFxwt8USGY1ajP1ZF5lM=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/seqdiagram/graphicbuilder.go
+++ b/seqdiagram/graphicbuilder.go
@@ -253,7 +253,7 @@ func (gb *graphicBuilder) getStartAndEndColsBasedOnContent(subItems []SequenceIt
 
 	innerRanks := getInnerRanksRecursive(subItems)
 	sort.Ints(innerRanks)
-	if len(innerRanks) > 0 {
+	if len(innerRanks) > 1 && innerRanks[0] != innerRanks[len(innerRanks)-1] {
 		// +1 because actor rank and column values are offset by one
 		startCol = innerRanks[0] + 1
 		endCol = innerRanks[len(innerRanks)-1] + 1

--- a/seqdiagram/graphicbuilder.go
+++ b/seqdiagram/graphicbuilder.go
@@ -269,12 +269,24 @@ func (gb *graphicBuilder) putBlockSegmentsSequentially(row *int, depth int, acti
 	startRow = *row
 	nestDepth := action.MaxNestDepth()
 
-	for i, seg := range action.Segments {
-		// To outline only the inner actors of the block we need to set...
-		//  - startCol to the leftmost inner actor of the block
-		//  - endCol to the rightmost inner actor of the block
-		startCol, endCol := gb.getStartAndEndColsBasedOnContent(seg.SubItems)
+	startCol := 0
+	endCol := gb.Graphic.Cols() - 1 // This needs to be the column of the last actor
 
+	// To outline only the inner actors of the sibling blocks we need to set...
+	//  - startCol to the leftmost inner actor of the sibling blocks
+	//  - endCol to the rightmost inner actor of the sibling blocks
+	for _, seg := range action.Segments {
+		segStartCol, segEndCol := gb.getStartAndEndColsBasedOnContent(seg.SubItems)
+
+		if segStartCol < startCol || startCol == 0 {
+			startCol = segStartCol
+		}
+		if segEndCol > endCol || endCol == gb.Graphic.Cols()-1 {
+			endCol = segEndCol
+		}
+	}
+
+	for i, seg := range action.Segments {
 		*row++
 		gb.putItemsInSlice(row, depth+1, seg.SubItems)
 		endRow = *row

--- a/seqdiagram/graphicbuilder.go
+++ b/seqdiagram/graphicbuilder.go
@@ -253,7 +253,6 @@ func (gb *graphicBuilder) getStartAndEndColsBasedOnContent(subItems []SequenceIt
 
 	innerRanks := getInnerRanksRecursive(subItems)
 	sort.Ints(innerRanks)
-	// log.Println(innerRanks)
 	if len(innerRanks) > 0 {
 		// +1 because actor rank and column values are offset by one
 		startCol = innerRanks[0] + 1

--- a/seqdiagram/graphicbuilder.go
+++ b/seqdiagram/graphicbuilder.go
@@ -236,21 +236,31 @@ func getInnerRanksRecursive(subItems []SequenceItem) []int {
 	ranks := []int{}
 	for _, subItem := range subItems {
 		if action, isAction := subItem.(*Action); isAction {
-			//			log.Printf("%d %#v\n", i, action)
-			//			log.Printf(" From: %#v\n", action.From)
-			//			log.Printf(" To  : %#v\n", action.To)
 			ranks = append(ranks, action.From.rank)
 			ranks = append(ranks, action.To.rank)
 		} else if block, isBlock := subItem.(*Block); isBlock {
-			//			log.Printf("%d %#v\n", i, block)
 			for _, segment := range block.Segments {
 				ranks = append(ranks, getInnerRanksRecursive(segment.SubItems)...)
 			}
-			//		} else {
-			//			log.Printf("%d ??? %#v\n", i, subItem)
 		}
 	}
 	return ranks
+}
+
+func (gb *graphicBuilder) getStartAndEndColsBasedOnContent(subItems []SequenceItem) (int, int) {
+	startCol := 0
+	endCol := gb.Graphic.Cols() - 1 // This needs to be the column of the last actor
+
+	innerRanks := getInnerRanksRecursive(subItems)
+	sort.Ints(innerRanks)
+	// log.Println(innerRanks)
+	if len(innerRanks) > 0 {
+		// +1 because actor rank and column values are offset by one
+		startCol = innerRanks[0] + 1
+		endCol = innerRanks[len(innerRanks)-1] + 1
+	}
+
+	return startCol, endCol
 }
 
 func (gb *graphicBuilder) putBlockSegmentsSequentially(row *int, depth int, action *Block) {
@@ -261,21 +271,10 @@ func (gb *graphicBuilder) putBlockSegmentsSequentially(row *int, depth int, acti
 	nestDepth := action.MaxNestDepth()
 
 	for i, seg := range action.Segments {
-		// default to full width of the diagram
-		startCol := 0
-		endCol := gb.Graphic.Cols() - 1 // This needs to be the column of the last actor
-
 		// To outline only the inner actors of the block we need to set...
 		//  - startCol to the leftmost inner actor of the block
 		//  - endCol to the rightmost inner actor of the block
-		innerRanks := getInnerRanksRecursive(seg.SubItems)
-		sort.Ints(innerRanks)
-		// log.Println(innerRanks)
-		if len(innerRanks) > 0 {
-			// +1 because actor rank and column values are offset by one
-			startCol = innerRanks[0] + 1
-			endCol = innerRanks[len(innerRanks)-1] + 1
-		}
+		startCol, endCol := gb.getStartAndEndColsBasedOnContent(seg.SubItems)
 
 		*row++
 		gb.putItemsInSlice(row, depth+1, seg.SubItems)

--- a/seqdiagram/treebuilder.go
+++ b/seqdiagram/treebuilder.go
@@ -205,10 +205,10 @@ func (tb *treeBuilder) getOrAddActor(ar parse.ActorRef, d *Diagram) (*Actor, err
 		case "right":
 			return RightOffsideActor, nil
 		default:
-			return nil, fmt.Errorf("Invalid pseudo actor: ", pn)
+			return nil, fmt.Errorf("Invalid pseudo actor: %s", pn)
 		}
 	default:
-		return nil, fmt.Errorf("Unknown actor reference")
+		return nil, fmt.Errorf("Unknown actor reference: %#v", a)
 	}
 }
 


### PR DESCRIPTION
Fixes #11 

**Q: Should I check in the `tests/testout.html` file as part of the PR?**
**Q: Perhaps it should be flagged behind a `--condensed-blocks` flag?**

Currently any diagram with several blocks and >5 columns becomes hard to eye parse...

<img width="362" alt="Screenshot 2020-10-08 at 22 03 26" src="https://user-images.githubusercontent.com/888751/95513351-1e2c9900-09b2-11eb-9063-36b779c9c708.png">

...this PR bounds blocks to the inner (including nested) content...

<img width="366" alt="Screenshot 2020-10-08 at 22 55 31" src="https://user-images.githubusercontent.com/888751/95517692-669b8500-09b9-11eb-98b3-04903e8c51fc.png">


```
participant One
participant Two
participant Three
participant Four
participant Five
participant Six
participant Seven
participant Eight
participant Nine
participant Ten

One->Two:

loop: loop1
  Two->Three:
  note over Three: woof
  loop: loop2
    Three->Four:
  end
end

Four->Five:

loop: loop3
  alt: xxx
    Six->Eight: oof
  elsealt: yyy
    Six->Nine: oof
  end
end
```

### Tests no longer fails (got a div by zero for a while there)

```
$ ./runtests.sh
Test: humanActorStyles.seq
Test: humanActors.seq
Test: humanActors2.seq
Test: offsideActors1.seq
Test: offsideActors2.seq
Test: offsideActors3.seq
Test: offsideActors4.seq
Test: optblock.seq
Test: test1.seq
Test: test2.seq
Test: test3.seq
Test: test4.seq
Test: test5.seq
Test: test6.seq
Test: test7.seq
Test: testComments.seq
Test: testConcurrent.seq
Test: testDeepNesting.seq
Test: testDividers.seq
Test: testDividersNoText.seq
Test: testIf.seq
Test: testIfElse.seq
Test: testIfSelf.seq
Test: testLargeObjectNames.seq
Test: testLoop.seq
Test: testMultiNotes.seq
Test: testMultiNotes2.seq
Test: testNestedIf.seq
Test: testNoActors.seq
Test: testNoBottomActors.seq
Test: testSelfArrows.seq
Test: testSelfArrows2.seq
Test: testSmallTitle.seq
Test: testStyles.seq
```

#### But the following look weird... (all (?) fixed now)

FIXED: Blocks don't align (sibling blocks are not taken into account) and the bottom dotted line is missing from the first block...

<img width="728" alt="Screenshot 2020-10-08 at 22 30 51" src="https://user-images.githubusercontent.com/888751/95515696-f3444400-09b5-11eb-8859-fe0cbb5f215e.png">

<img width="669" alt="Screenshot 2020-10-08 at 22 48 37" src="https://user-images.githubusercontent.com/888751/95517239-89796980-09b8-11eb-951f-b61c499b0172.png">

FIXED: Well this just looks plain odd... but I think it's another case of sibling block sizes not being taken into account...

<img width="822" alt="Screenshot 2020-10-08 at 22 33 51" src="https://user-images.githubusercontent.com/888751/95515990-72397c80-09b6-11eb-860a-d7c54b4f986d.png">

<img width="776" alt="Screenshot 2020-10-08 at 22 48 52" src="https://user-images.githubusercontent.com/888751/95517223-87170f80-09b8-11eb-9e1f-ea109a3b509f.png">
